### PR TITLE
Add husky prepush hook and refactor InputProps interface

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "biome check .",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.1",
@@ -31,6 +32,7 @@
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",
     "autoprefixer": "^10.4.16",
+    "husky": "8.0.3",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3"

--- a/src/shared/components/input.tsx
+++ b/src/shared/components/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/shared/utils/string";
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,6 +1991,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 6722591771c657b91a1abb082e07f6547eca79144d678e586828ae806499d90dce2a6aee08b66183fd8b085f19d20e0990a2ad396961746b4c8bd5bdb619d668
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -3214,6 +3223,7 @@ __metadata:
     autoprefixer: "npm:^10.4.16"
     class-variance-authority: "npm:^0.7.0"
     clsx: "npm:^2.1.0"
+    husky: "npm:8.0.3"
     lucide-react: "npm:^0.303.0"
     next: "npm:14.0.4"
     postcss: "npm:^8.4.32"


### PR DESCRIPTION
This pull request adds a husky prepush hook to inject a githook that runs the command "yarn lint" before pushing. It also refactors the InputProps interface in input.tsx to use a type alias instead of extending React.InputHTMLAttributes<HTMLInputElement>.